### PR TITLE
fix(transaction): end day transaction doesn't count in duration

### DIFF
--- a/src/pages/Conversation.vue
+++ b/src/pages/Conversation.vue
@@ -12,6 +12,10 @@ import ProfileCard from 'src/components/ProfileCard'
 import PageComponentMixin from 'src/mixins/pageComponent'
 import AppUpload from 'src/mixins/AppUpload'
 
+import {
+  convertEndDateFromAPIToUI
+} from 'src/utils/time'
+
 export default {
   components: {
     TransactionActions,
@@ -54,7 +58,9 @@ export default {
       return this.inbox.transaction.startDate ? new Date(this.inbox.transaction.startDate) : undefined
     },
     endDate () {
-      return this.inbox.transaction.endDate ? new Date(this.inbox.transaction.endDate) : undefined
+      return this.inbox.transaction.endDate
+        ? new Date(convertEndDateFromAPIToUI(this.inbox.transaction.endDate, { startDate: this.startDate }))
+        : undefined
     },
     groupedChatMessages () {
       const messageGroups = this.inbox.conversationMessages.reduce((groups, m, i) => {

--- a/src/store/transaction/getters.js
+++ b/src/store/transaction/getters.js
@@ -22,7 +22,7 @@ export function validTransactionOptions (state, getters, rootState, rootGetters)
 
   if (transactionDatesRequired) {
     if (!startDate || !endDate) return false
-    if (endDate < startDate) return false
+    if (endDate <= startDate) return false
 
     const availableQuantity = getAvailableQuantityByDate({ availabilityGraph, startDate, endDate })
     return availableQuantity >= quantity

--- a/src/utils/time.js
+++ b/src/utils/time.js
@@ -1,3 +1,7 @@
+import { date } from 'quasar'
+
+const { addToDate } = date
+
 export function isValidDateString (value) {
   try {
     const date = new Date(value) // eslint-disable-line no-new
@@ -5,4 +9,55 @@ export function isValidDateString (value) {
   } catch (err) {
     return false
   }
+}
+
+const mapQuasarTimeUnitToStelace = {
+  m: 'minutes',
+  h: 'hours',
+  d: 'days',
+  M: 'months'
+}
+
+function getQuasarTimeUnit (timeUnit) {
+  return mapQuasarTimeUnitToStelace[timeUnit]
+}
+
+export function convertEndDateFromAPIToUI (endDate, { startDate, timeUnit = 'd', includeEndDate = true } = {}) {
+  if (!includeEndDate) return endDate
+
+  const quasarTimeUnit = getQuasarTimeUnit(timeUnit)
+
+  if (!endDate) return endDate
+  const newEndDate = addToDate(new Date(endDate).toISOString(), { [quasarTimeUnit]: -1 }).toISOString()
+
+  // align the offset to start date to avoid non-integer duration
+  const differenceOffset = getOffsetDifference(startDate, newEndDate)
+  if (differenceOffset) {
+    return addToDate(newEndDate, { minutes: differenceOffset }).toISOString()
+  } else {
+    return newEndDate
+  }
+}
+
+export function convertEndDateFromUIToAPI (endDate, { startDate, timeUnit = 'd', includeEndDate = true } = {}) {
+  if (!includeEndDate) return endDate
+
+  const quasarTimeUnit = getQuasarTimeUnit(timeUnit)
+
+  if (!endDate) return endDate
+  const newEndDate = addToDate(new Date(endDate).toISOString(), { [quasarTimeUnit]: 1 }).toISOString()
+
+  // align the offset to start date to avoid non-integer duration
+  const differenceOffset = getOffsetDifference(startDate, newEndDate)
+  if (differenceOffset) {
+    return addToDate(newEndDate, { minutes: -differenceOffset }).toISOString()
+  } else {
+    return newEndDate
+  }
+}
+
+export function getOffsetDifference (startDate, endDate) {
+  const endDateOffset = new Date(endDate).getTimezoneOffset()
+  const startDateOffset = startDate ? new Date(startDate).getTimezoneOffset() : endDateOffset
+  return endDateOffset - startDateOffset
 }


### PR DESCRIPTION
Previously, it wasn't possible to select same day for
start date and end date
because it was considered as zero duration and is rejected
by API.

Now, end date is included to the duration computation.
Selected dates 2019-01-01 to 2019-01-01 will count as
1 day duration.