### PR TITLE
fix : wrong filter dialog transition

### DIFF
--- a/src/components/SearchToolbar.vue
+++ b/src/components/SearchToolbar.vue
@@ -349,8 +349,8 @@ export default {
     <QDialog
       :value="showFilterDialog"
       maximized
-      transition-show="slide-left"
-      transition-hide="slide-right"
+      transition-show="slide-right"
+      transition-hide="slide-left"
       content-class="filter-dialog"
       @hide="hideFilterDialog"
     >


### PR DESCRIPTION
Makes much more sense to me this way, especially when the filter dialog doesn't fill the whole window (on bigger screens)