### PR TITLE
Use AppAvatar in conversation

### DIFF
--- a/src/pages/Conversation.vue
+++ b/src/pages/Conversation.vue
@@ -446,7 +446,6 @@ export default {
             :key="message.id"
             class="q-mb-md"
             :name="message.senderId === currentUser.id ? currentUser.displayName : inbox.interlocutor.displayName"
-            :avatar="message.senderId === currentUser.id ? currentUserAvatar : interlocutorAvatar"
             :text="message.contents"
             text-sanitize
             :sent="message.senderId === currentUser.id"
@@ -457,7 +456,15 @@ export default {
               ? (style.colorfulTheme ? 'primary' : 'grey-8')
               : style.colorfulTheme ? 'secondary' : lightBackgroundColor"
             :stamp="getTimestamp(message.createdDate)"
-          />
+          >
+            <template v-slot:avatar>
+              <AppAvatar
+                class="q-mx-sm"
+                :user="message.senderId === currentUser.id ? currentUser : inbox.interlocutor"
+                size="3rem"
+              />
+            </template>
+          </QChatMessage>
         </component>
 
         <QSeparator


### PR DESCRIPTION
Better consistency across the app, and allows to display the usual placeholder when no picture is available (this situation was not handled at all, the browser was rendering the avatar as a broken image link)