### PR TITLE
Fix : Timestamp for dates older than 7 days

### DIFF
--- a/src/pages/Conversation.vue
+++ b/src/pages/Conversation.vue
@@ -160,7 +160,7 @@ export default {
       const delay = this.fromNow(date)
 
       if (delay.timeUnit === 'd' && delay.nbUnits > 7) {
-        return this.$t({ id: 'time.date_long' }, { date })
+        return this.$t({ id: 'time.date_long' }, { date: new Date(date) })
       }
 
       return this.$t({ id: 'time.ago' }, {


### PR DESCRIPTION
I changed this after seeing some wrongfully rendered timestamps on my earlier test messages. This version works for me !