### PR TITLE
refactor: adapt ratings fetch with list filter changes

### DIFF
--- a/src/pages/PublicProfile.vue
+++ b/src/pages/PublicProfile.vue
@@ -99,7 +99,7 @@ export default {
     loadProfile () {
       return Promise.all([
         this.fetchUserAssets(),
-        this.fetchRatingsStatsByTargetId({ targetId: [this.selectedUserId] }),
+        this.fetchRatingsStatsByTargetId({ targetId: this.selectedUser.id }),
         this.fetchUserRatingsByTransaction({ userId: this.selectedUser.id })
       ])
     },
@@ -110,11 +110,13 @@ export default {
     },
     fetchRatingsStatsByTargetId ({ targetId }) {
       if (!this.ratingsActive) return
+      if (!targetId) return
 
       return this.$store.dispatch('fetchRatingsStats', { targetId, groupBy: 'targetId' })
     },
     async fetchUserRatingsByTransaction ({ userId }) {
       if (!this.ratingsActive) return
+      if (!userId) return
 
       this.userRatingsByTransaction = await this.$store.dispatch('fetchRatingsByTransaction', { targetId: userId })
       this.userRatingsLoaded = true

--- a/src/store/inbox/actions.js
+++ b/src/store/inbox/actions.js
@@ -74,7 +74,7 @@ export async function fetchMessages ({ commit, dispatch, state, rootGetters }, {
   const fetchAssetsRequest = (...args) => stelace.assets.list(...args)
   const fetchAllAssets = fetchAllResults(fetchAssetsRequest, { id: assetsIds })
 
-  const assets = await fetchAllAssets
+  const assets = assetsIds.length ? await fetchAllAssets : []
 
   usersIds = compact(uniqBy(usersIds.concat(assets.map(asset => asset.ownerId))))
 

--- a/src/store/inbox/actions.js
+++ b/src/store/inbox/actions.js
@@ -114,7 +114,10 @@ export const fetchMessages = debounce(async function ({ commit, dispatch, state,
 
   if (rootGetters.ratingsActive) {
     const transactionsIds = uniqBy(allTransactions.map(b => b.id))
-    const assetIds = uniqBy(assets.map(asset => asset.id))
+    const assetIds = uniqBy(compact(
+      allTransactions.map(t => t.assetId) // assets referenced from transactions
+        .concat(assets.map(asset => asset.id))
+    ))
 
     await Promise.all([
       dispatch('fetchRatingsStats', { targetId: usersIds, groupBy: 'targetId' }),

--- a/src/store/inbox/actions.js
+++ b/src/store/inbox/actions.js
@@ -1,10 +1,12 @@
-import { compact, uniqBy } from 'lodash'
+import { compact, uniqBy, debounce } from 'lodash'
 import stelace, { fetchAllResults } from 'src/utils/stelace'
 import * as types from 'src/store/mutation-types'
 
 import { isAssetId } from 'src/utils/id'
 
-export async function fetchMessages ({ commit, dispatch, state, rootGetters }, { forceRefreshAll = false } = {}) {
+const maxNetworkResourceDelay = 2000 // calls debounced up to this value
+
+export const fetchMessages = debounce(async function ({ commit, dispatch, state, rootGetters }, { forceRefreshAll = false } = {}) {
   // fetch the current user here
   // getters.currentUser may have not been populated in time
   // OR the current user changes (login/logout or organization)
@@ -120,7 +122,7 @@ export async function fetchMessages ({ commit, dispatch, state, rootGetters }, {
       dispatch('fetchRatedTransactions', { transactionsIds })
     ])
   }
-}
+}, maxNetworkResourceDelay, { leading: true, trailing: false })
 
 export async function setConversationArchivedStatus ({ commit, state, getters }, { conversationId, archived }) {
   const currentUser = getters.currentUser

--- a/src/store/rating/actions.js
+++ b/src/store/rating/actions.js
@@ -42,9 +42,7 @@ export async function fetchRatingsStats ({ commit, rootGetters }, { assetId, tar
  * Returns an array of ratings with property owner added
  */
 export async function fetchRatingsByTransaction ({ rootGetters }, { targetId, assetId }) {
-  const fetchRatings = (...args) => stelace.ratings.list(...args)
-
-  const ratings = await fetchAllResults(fetchRatings, { targetId, assetId, label: 'main' })
+  const ratings = await api.fetchRatings({ targetId, assetId, label: 'main' })
 
   const usersIds = uniqBy(compact(ratings.map(rating => rating.authorId)))
 
@@ -94,8 +92,7 @@ export async function fetchRatedTransactions ({ commit, rootGetters }, { transac
 }
 
 export async function fetchRatings ({ commit }, { transactionId }) {
-  const ratings = await stelace.ratings.list({ transactionId })
-  return ratings
+  return api.fetchRatings({ transactionId })
 }
 
 export async function createRating ({ commit }, { attrs }) {

--- a/src/store/rating/api.js
+++ b/src/store/rating/api.js
@@ -1,5 +1,6 @@
 import stelace, { fetchAllResults } from 'src/utils/stelace'
 import pMap from 'p-map'
+import { isEmpty } from 'lodash'
 
 const fetchRatingsRequest = (...args) => stelace.ratings.list(...args)
 const fetchRatingsStatsRequest = (...args) => stelace.ratings.getStats(...args)
@@ -54,6 +55,14 @@ async function fetchRatingsHelper (params, fetchRequest) {
     if (Array.isArray(transactionId)) filterValues = transactionId
     else filterValues = [transactionId]
   }
+
+  const arrayFilters = ['authorId', 'targetId', 'assetId', 'transactionId']
+  const hasEmptyArrayFilter = arrayFilters.some(filter => {
+    return Array.isArray(clonedParams[filter]) && isEmpty(clonedParams[filter])
+  })
+
+  // do not perform the request
+  if (hasEmptyArrayFilter) return []
 
   if (filter) {
     delete clonedParams.assetId

--- a/src/store/rating/api.js
+++ b/src/store/rating/api.js
@@ -1,5 +1,5 @@
 import stelace, { fetchAllResults } from 'src/utils/stelace'
-import pMap from 'p-map'
+import p from 'src/utils/promise'
 import { isEmpty } from 'lodash'
 
 const fetchRatingsRequest = (...args) => stelace.ratings.list(...args)
@@ -68,7 +68,7 @@ async function fetchRatingsHelper (params, fetchRequest) {
     delete clonedParams.assetId
     delete clonedParams.transactionId
 
-    const ratingsStatsByFilterValue = await pMap(filterValues, filterValue => {
+    const ratingsStatsByFilterValue = await p.map(filterValues, filterValue => {
       return fetchAllResults(fetchRequest, {
         ...clonedParams,
         [filter]: filterValue,

--- a/src/store/search/actions.js
+++ b/src/store/search/actions.js
@@ -1,4 +1,4 @@
-import { compact, uniqBy, pick } from 'lodash'
+import { compact, uniqBy, pick, isEmpty } from 'lodash'
 import stelace, { fetchAllResults } from 'src/utils/stelace'
 import * as types from 'src/store/mutation-types'
 import * as api from './api'
@@ -112,7 +112,7 @@ export async function searchAssets ({ state, rootState, rootGetters, commit, dis
 
   if (usersIds.length) {
     const fetchUserRequest = (...args) => stelace.users.list(...args)
-    users = await fetchAllResults(fetchUserRequest, { id: usersIds })
+    users = !isEmpty(usersIds) ? await fetchAllResults(fetchUserRequest, { id: usersIds }) : []
 
     commit({
       type: types.SEARCH__SET_USERS,


### PR DESCRIPTION
- transform array filter into single value filter for `assetId` and `transactionId`
- some performance improvements to reduce number of requests sent
- customize fetching method if there is only one rating type (use list endpoint instead of stats)
- fix ratings targeting assets referenced by transactions that weren't fetched